### PR TITLE
Resolving LibSodium Error on PHP Startup

### DIFF
--- a/php/7/Dockerfile
+++ b/php/7/Dockerfile
@@ -102,7 +102,7 @@ RUN printf "\n" | pecl install yaml-2.0.0 && \
 
 # Install ext-libsodium
 RUN printf "\n" | pecl install -a libsodium && \
-    echo 'extension=libsodium.so' | tee /etc/php/7.0/mods-available/libsodium.ini && \
+    echo 'extension=sodium.so' | tee /etc/php/7.0/mods-available/libsodium.ini && \
     ln -s /etc/php/7.0/mods-available/libsodium.ini /etc/php/7.0/cli/conf.d/20-libsodium.ini
 
 # Install ext-xdebug


### PR DESCRIPTION
libsodium.so -> sodium.so resolves error: `PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php/20151012/libsodium.so' - /usr/lib/php/20151012/libsodium.so: cannot open shared object file: No such file or directory in Unknown on line 0`