### PR TITLE
 Added php-fpm:7.1 Dockerfile 

### DIFF
--- a/php-fpm/7.1/Dockerfile
+++ b/php-fpm/7.1/Dockerfile
@@ -1,0 +1,23 @@
+#
+# PHP-FPM 7.1 Dockerfile
+#
+# https://github.com/phalcon/dockerfiles
+#
+
+# Pull base image
+FROM php:7.1-fpm
+
+MAINTAINER Serghei Iakovlev <serghei@phalconphp.com>
+
+RUN curl -O https://codeload.github.com/phalcon/cphalcon/tar.gz/v3.2.4
+RUN tar xvzf v3.2.1
+RUN cd cphalcon-3.2.1/build && ./install
+RUN cd ../../ && rm -Rf cphalcon-3.2.4 && rm -Rf v3.2.4
+RUN echo "extension=phalcon.so" > /usr/local/etc/php/conf.d/phalcon.ini
+
+RUN apt-get autoremove -y && \
+    apt-get autoclean -y && \
+    apt-get clean -y && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /etc/php5 /etc/php/5* /usr/lib/php/20121212 /usr/lib/php/20131226
+
+RUN rm -rf /var/log /var/cache

--- a/php-fpm/7.1/Makefile
+++ b/php-fpm/7.1/Makefile
@@ -1,6 +1,5 @@
 NAME = phalconphp/php-fpm
 VERSION = 7.1
-ALIAS = 7.1
 SHELL = /bin/bash
 
 .PHONY: pre-build docker-build post-build build release push tag do-push post-push
@@ -19,12 +18,11 @@ release: build tag push
 push: do-push post-push
 
 tag:
-	docker tag $(NAME):$(VERSION) $(NAME):$(ALIAS)
+	docker tag $(NAME):$(VERSION) $(NAME):$(VERSION)
 	docker tag $(NAME):$(VERSION) $(NAME):latest
 
 do-push:
 	docker push $(NAME):$(VERSION)
-	docker push $(NAME):$(ALIAS)
 	docker push $(NAME):latest
 
 post-push:

--- a/php-fpm/7.1/Makefile
+++ b/php-fpm/7.1/Makefile
@@ -1,0 +1,32 @@
+NAME = phalconphp/php-fpm
+VERSION = 7.1
+ALIAS = 7.1
+SHELL = /bin/bash
+
+.PHONY: pre-build docker-build post-build build release push tag do-push post-push
+
+build: pre-build docker-build post-build
+
+pre-build:
+
+post-build:
+
+docker-build:
+	docker build -t $(NAME):$(VERSION) --no-cache --rm .
+
+release: build tag push
+
+push: do-push post-push
+
+tag:
+	docker tag $(NAME):$(VERSION) $(NAME):$(ALIAS)
+	docker tag $(NAME):$(VERSION) $(NAME):latest
+
+do-push:
+	docker push $(NAME):$(VERSION)
+	docker push $(NAME):$(ALIAS)
+	docker push $(NAME):latest
+
+post-push:
+
+# vim:ft=make:noet:ci:pi:sts=0:sw=4:ts=4:tw=78:fenc=utf-8:et


### PR DESCRIPTION
Added php-fpm:7.1 Dockerfile

This version is also including latest Phalcon v3.2.4

Please include this version of Dockerfile and than push it to dockerhub.

I leaved you Serghei as a maintainer, since you maintain most of Dockerfiles here.