### PR TITLE
Add missing entrypoint instruction in Dockerfile

### DIFF
--- a/app/ubuntu-16.04/php-7.2/Dockerfile
+++ b/app/ubuntu-16.04/php-7.2/Dockerfile
@@ -262,6 +262,7 @@ VOLUME /app \
        /var/lib/nginx/proxy
 
 WORKDIR /app
+ENTRYPOINT ["/entrypoint.sh"]
 
 # Local Variables:
 # tab-width: 4

--- a/app/ubuntu-16.04/php-7.2/entrypoint.d/01-xdebug-setup.sh
+++ b/app/ubuntu-16.04/php-7.2/entrypoint.d/01-xdebug-setup.sh
@@ -20,7 +20,7 @@ if [ "x${XDEBUG_REMOTE_ENABLE}" != "x" ]; then
     # Setting XDEBUG_REMOTE_ENABLE=1 will enable xdebug
     case $XDEBUG_REMOTE_ENABLE in
 	"1"|"on"|"On"|"ON"|"true"|"True"|"TRUE")
-	    phpenmod -v 7.1 xdebug;
+	    phpenmod -v 7.2 xdebug;
 	    ;;
     esac
 fi


### PR DESCRIPTION
`ENTRYPOINT` Instruction is missing in the `Dockerfile`, due to which xdebug is not enabled even when correct environment variable is provided.

I identified the bug from this [SO question](https://stackoverflow.com/questions/61114771/how-to-enable-xdebug-on-phalconphp-ubuntu-16-04-docker-image)